### PR TITLE
mc1.19.2-v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ This is a mod that automatically converts Romaji sent in chat to Hiragana.
 ## Usage
 
 When you send a message in chat, it will be automatically converted to Hiragana. Example: `konnnitiha` → `こんにちは`  
-If you put one of the symbols `!#;` at the beginning of the message, it will not be converted. Example: `#Hello, world!` → `Hello, world!`  
-Also, messages with less than 5 characters will not be converted. To force conversion, put one of the symbols `\¥￥` at the beginning of the message. Example: `hi` → `hi`, `\yaa` → `やあ`  
+If you put one of the symbols `!#;` at the beginning of the message, it will not be converted. Example: `#Hello, world!` → `#Hello, world!`  
+Also, messages with less than 5 characters will not be converted. To force conversion, put one of the symbols `\¥￥` at the beginning of the message. Example: `yaa` → `yaa`, `\yaa` → `やあ`  
+
+
+## Installation
+
+- [Modrinth](https://modrinth.com/mod/japaneseromajiconverter)(recommended)
+- [CurseForge](https://www.curseforge.com/minecraft/mc-mods/japanese-romaji-converter)
+- [GitHub Releases](https://github.com/Meatwo310/JapaneseRomajiConverter-Forge/releases)
 
 
 ## Credits
@@ -61,8 +68,16 @@ This project is licensed under the Apache License 2.0. See [LICENSE](./LICENSE) 
 ## 使い方
 
 チャットでローマ字を送信すると自動的にひらがなに変換されます。 例:`konnnitiha`→`こんにちは`  
-`!#;`のいずれかの記号をメッセージの先頭につけると、変換されなくなります。 例:`#Hello, world!`→`Hello, world!`  
-また、5文字未満のメッセージは変換されません。 強制的に変換するには、`\¥￥`のいずれかの記号をメッセージの先頭につけてください。 例:`hi`→`hi`,`\yaa`→`やあ`  
+`!#;`のいずれかの記号をメッセージの先頭につけると、変換されなくなります。 例:`#Hello, world!`→`#Hello, world!`  
+また、5文字未満のメッセージは変換されません。 強制的に変換するには、`\¥￥`のいずれかの記号をメッセージの先頭につけてください。 例:`yaa`→`yaa`,`\yaa`→`やあ`  
+
+
+## インストール
+
+- [Modrinth](https://modrinth.com/mod/japaneseromajiconverter)(推奨)
+- [CurseForge](https://www.curseforge.com/minecraft/mc-mods/japanese-romaji-converter)
+- [GitHub Releases](https://github.com/Meatwo310/JapaneseRomajiConverter-Forge/releases)
+
 
 
 ## クレジット

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.19.2
 # The Minecraft version range can use any release version of Minecraft as bounds.
 # Snapshots, pre-releases, and release candidates are not guaranteed to sort properly
 # as they do not follow standard versioning conventions.
-minecraft_version_range=[1.19.2,1.20)
+minecraft_version_range=[1.19.2,1.19.3)
 # The Forge version must agree with the Minecraft version to get a valid artifact
 forge_version=43.2.0
 # The Forge version range can use any version of Forge as bounds or match the loader version range
@@ -42,7 +42,7 @@ mod_name=Japanese Romaji Converter
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=Apache-2.0
 # The mod version. See https://semver.org/
-mod_version=1.0.0
+mod_version=1.1.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/meatwo310/japaneseromajiconverter/ChatCustomizer.java
+++ b/src/main/java/com/meatwo310/japaneseromajiconverter/ChatCustomizer.java
@@ -7,6 +7,8 @@ import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
+import java.util.Objects;
+
 @Mod.EventBusSubscriber
 public class ChatCustomizer {
     // private static final Logger LOGGER = LogUtils.getLogger();
@@ -23,31 +25,39 @@ public class ChatCustomizer {
             return;
         }
 
-        // String resultText = "<" + entity.getDisplayName().getString() + "> ";
+        if (baseText.isEmpty()) {
+            // 空文字は変換しない
+            return;
+        }
+
         String resultText;
+        final String convertedText = RomajiToHiragana.convert(baseText);
 
         // メッセージを条件に応じて変換
-        if (baseText.isEmpty()) {
-            // 空文字の場合は変換しない
+        if (Objects.equals(convertedText, baseText)) {
+            // 変換前後で文字列が変わらない場合は変換しない
             return;
-        }  else if (baseText.length() < 5 && !baseText.matches("^[\\\\¥￥].*$")) {
-            // 短すぎる場合は変換しない(\や¥などで始まる場合は変換)
+        } else if (baseText.matches("^[!#;].*$")) {
+            // !#;で始まる場合は変換しないが、頭文字はグレーに変換する
+            resultText = "§7" + baseText.charAt(0) + "§r" + baseText.substring(1);
+        } else if (baseText.matches("^[\\\\¥￥].*$")) {
+            // \¥￥で始まる場合は頭文字を取り除いて強制的に変換し、括弧付きで原文を示す
+            resultText = RomajiToHiragana.convert(baseText.substring(1)) + " §7(" + baseText + ")";
+        } else if (baseText.length() < 5) {
+            // 短すぎる場合は変換しない
             return;
         } else if (baseText.startsWith(":")) {
             // :で始まる場合は変換しない
             return;
         } else if (!baseText.matches("^[!-~\\s¥￥]+$")) {
-            // ASCII文字や\¥￥以外の文字が含まれる場合は変換しない
+            // ASCII文字のみではない場合は変換しない
             return;
-        } else if (baseText.matches("^[!#;].*$")) {
-            // !#;で始まる場合は変換しないが、頭文字を取り除いて括弧付きで元のメッセージを示す
-            resultText = baseText.substring(1) + " §7(" + baseText + ")";
-        } else if (baseText.matches("^[\\\\¥￥].*$")) {
-            // \¥￥で始まる場合は、頭文字を取り除いて変換し、括弧付きで元のメッセージを示す
-            resultText = RomajiToHiragana.convert(baseText.substring(1)) + " §7(" + baseText + ")";
+        } else if (convertedText.replaceAll("[^a-zA-Z]", "").length() > convertedText.length() * 0.25) {
+            // 変換結果にアルファベットが多く含まれる場合は変換しない
+            resultText = baseText + " §8(変換失敗)";
         } else {
-            // 条件に当てはまらない普通のローマ字メッセージは変換
-            resultText = RomajiToHiragana.convert(baseText) + " §7(" + baseText + ")";
+            // 条件に当てはまらない普通のローマ字メッセージは変換を試みる
+            resultText = convertedText + " §7(" + baseText + ")";
         }
 
         // 変換結果を送信


### PR DESCRIPTION
- #1 変換前と変換後のメッセージが同等な場合変換を行わないように
- #2 if文の順序を変更することで、文字数が短い場合でも!#;のプレフィックスを認識するように
- #3 !#;のプレフィックスが使用されているメッセージは、プレフィックスをグレーで表示し、余分な原文を表示しないように
- READMEにインストール方法を記載